### PR TITLE
Fix for missing PokeDex module

### DIFF
--- a/src/models/Player/index.js
+++ b/src/models/Player/index.js
@@ -4,7 +4,7 @@ import Bag from "./Bag";
 import Info from "./Info";
 import Party from "./Party";
 import Avatar from "./Avatar";
-import Pokedex from "./Pokedex";
+import Pokedex from "./PokeDex";
 import Contact from "./Contact";
 import CandyBag from "./CandyBag";
 import Tutorial from "./Tutorial";


### PR DESCRIPTION
Fixes Error: Cannot find module './Pokedex' on 'npm run boot'