### PR TITLE
Fix import error due to capitalization

### DIFF
--- a/src/models/Player/index.js
+++ b/src/models/Player/index.js
@@ -4,7 +4,7 @@ import Bag from "./Bag";
 import Info from "./Info";
 import Party from "./Party";
 import Avatar from "./Avatar";
-import Pokedex from "./Pokedex";
+import PokeDex from "./PokeDex";
 import Contact from "./Contact";
 import CandyBag from "./CandyBag";
 import Tutorial from "./Tutorial";


### PR DESCRIPTION
Cannot find module './Pokedex' will come up because linux has a different case check, so it cannot import it.